### PR TITLE
aiart: switch to rapidfuzz

### DIFF
--- a/aiart/info.json
+++ b/aiart/info.json
@@ -3,7 +3,7 @@
     "description": "Generate incredible art using AI.",
     "install_msg": "Thanks for installing!",
     "name": "AIArt",
-    "requirements": ["pillow", "thefuzz"],
+    "requirements": ["pillow"],
     "short": "Generate incredible art using AI.",
     "min_bot_version": "3.5.0"
 }

--- a/aiart/wombo.py
+++ b/aiart/wombo.py
@@ -9,7 +9,7 @@ from PIL import Image
 from redbot.core import commands
 from redbot.core.commands import BadArgument, Context, Converter
 from redbot.core.utils.chat_formatting import humanize_list
-from thefuzz import process
+from rapidfuzz import process
 
 from .abc import MixinMeta
 from .utils import NoExitParser


### PR DESCRIPTION
switch to using rapidfuzz in place of thefuzz to use the same lib as Red discord bot,
fixes the following error message in the bot's logs:
```
/data/cogs/Downloader/lib/thefuzz/fuzz.py:11: UserWarning: Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning
  warnings.warn('Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning')
```

(rapidfuzz is mostly a drop-in replacement to thefuzz)
This change worked fine from the tests i did on my bot